### PR TITLE
Initial work to point the riff bits at the a system function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+evergreen-node-system-function-buildpack*.tgz
+src/node_modules/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License:
+
+Copyright (C) 2020 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+VERSION := "v$$(cat buildpack.toml | grep version | sed -e 's/version = //g' | xargs)"
+
+clean:
+	-rm -f evergreen-node-system-function-buildpack-$(VERSION).tgz
+
+package: clean
+	@tar cvzf evergreen-node-system-function-buildpack-$(VERSION).tgz bin/ src/ buildpack.toml README.md LICENSE
+
+release:
+	@git tag $(VERSION)
+	@git push --tags origin master

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+
+layers_dir=$1
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo -e 'launch = true' > $layers_dir/system-function.toml
+system_dir=$layers_dir/system-function
+mkdir -p $system_dir
+
+echo "---> Evergreen Node System Function Buildpack"
+
+# COPY and install node/npm on into a layer
+cp -R $DIR/../src/* $system_dir
+pushd $system_dir
+npm install
+popd
+
+mkdir -p $system_dir/env.launch
+echo -n "$system_dir" > $system_dir/env.launch/FUNCTION_URI.override
+echo -n "/workspace" > $system_dir/env.launch/USER_FUNCTION_URI.override
+
+exit 0

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+exit 0

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,0 +1,12 @@
+api = "0.2"
+
+[buildpack]
+id = "heroku/evergreen-node-system-function"
+name = "Evergreen Node System Function"
+version = "0.0.1"
+
+[[stacks]]
+id = "heroku-18"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,86 @@
+const {Message} = require('@projectriff/message');
+
+const {DEBUG, MIDDLEWARE_FUNCTION_URI, USER_FUNCTION_URI} = process.env;
+
+function getMiddlewareFunctions(uri) {
+  const middlewareFunctions = [];
+  if (uri) {
+    uri.split(':').forEach(mw => middlewareFunctions.push(getFunction(mw)))
+  }
+  return middlewareFunctions;
+}
+
+function getFunction(uri) {
+  let mod;
+  try {
+    mod = require(uri);
+  } catch (e) {
+    throw `Could not locate user function at ${uri}: ${e}`
+  }
+  if (mod.__esModule && typeof mod.default === 'function') {
+    return mod.default;
+  }
+  return mod;
+}
+
+const middlewareFns = getMiddlewareFunctions(MIDDLEWARE_FUNCTION_URI);
+const userFn = getFunction(USER_FUNCTION_URI);
+
+module.exports = async (message) => {
+  const payload = message.payload;
+  // Remap headers to a standard JS object
+  const headers = message.headers.toRiffHeaders();
+  Object.keys(headers).map((key) => {headers[key] = message.headers.getValue(key)});
+  if (DEBUG) {
+    console.log('==System Function Start==');
+    console.log(`HEADERS: ${JSON.stringify(headers)}`);
+    console.log(`PAYLOAD: ${JSON.stringify(payload)}`);
+    console.log(`MIDDLEWARE_FUNCTION_URI: ${MIDDLEWARE_FUNCTION_URI}`);
+    console.log('==Middleware Function(s) Start==');
+  }
+
+  const state = {};
+  let middlewareResult = [payload];
+
+  await Promise.all(middlewareFns.map(async (middleware) => {
+    try {
+      // input should be immutable
+      const input = {
+        payload: typeof payload == "object" ? Object.assign({}, payload) : payload,
+        headers: Object.assign({}, headers)
+      };
+      if (DEBUG) {
+        console.log(`MIDDLEWARE INPUT: ${JSON.stringify(input)}`);
+        console.log(`MIDDLEWARE STATE: ${JSON.stringify(state)}`);
+        console.log(`MIDDLEWARE RESULT: ${JSON.stringify(middlewareResult)}`);
+      }
+      middlewareResult = await middleware(input, state, middlewareResult);
+      if (DEBUG) {
+        console.log(`MIDDLEWARE RETURNED: ${JSON.stringify(middlewareResult)}`);
+      }
+      if (!Array.isArray(middlewareResult)) {
+        throw new Error('Invalid return type, middleware must return an array of arguments')
+      }
+    } catch (err) {
+      throw err
+    }
+  })
+  );
+
+  if (DEBUG) {
+    console.log('==Middleware Function(s) End==');
+    console.log(`USER FUNCTION RECEIVED ARGS: ${JSON.stringify(middlewareResult)}`);
+  }
+
+  const result = await userFn(...middlewareResult);
+
+  if (DEBUG) {
+    console.log('RESULT', result);
+    console.log('==System Function End==');
+  }
+  return result;
+};
+
+module.exports.$argumentType = 'message';
+module.exports.$init = userFn.$init;
+module.exports.$destroy = userFn.$destroy;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-function-buildpack",
+  "version": "0.4.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@projectriff/message": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@projectriff/message/-/message-1.0.0.tgz",
+      "integrity": "sha512-FXeWHhz5EeMvK/GKb0u0Uvd/nxR8+5PZIUkb62ZU1ym1XLli6PGp0zfDErpNUMkhAulTwyHZWEJlIjWXU51A4A=="
+    }
+  }
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "evergreen-node-system-function",
+  "version": "0.0.1",
+  "description": "A node function to integrate with riff and an evergreen function.",
+  "dependencies": {
+    "@projectriff/message": "^1.0.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/heroku/evergreen-node-system-function.git"
+  },
+  "author": "@heroku",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/heroku/evergreen-node-system-function/issues"
+  },
+  "homepage": "https://github.com/heroku/evergreen-node-system-function#readme"
+}


### PR DESCRIPTION
This buildpack will be used instead of forking riff's node-function-buildpack. The `FUNCTION_URI` is overridable and we can use that to point the launch at the system function we build, which then in turn will point at the `/workspace` function the user builds.